### PR TITLE
fix: ensure delete events are considered by using finalizers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -513,16 +513,13 @@ struct SecurityAddon;
 
 impl Modify for SecurityAddon {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
-        openapi
-            .components
-            .as_mut()
-            .unwrap()
-            .security_schemes
-            .insert(
+        if let Some(components) = openapi.components.as_mut() {
+            components.security_schemes.insert(
                 "api_key".to_string(),
                 SecurityScheme::ApiKey(utoipa::openapi::security::ApiKey::Header(
                     ApiKeyValue::new("x-api-key"),
                 )),
             );
+        }
     }
 }

--- a/src/bin/generate-openapi.rs
+++ b/src/bin/generate-openapi.rs
@@ -5,6 +5,6 @@ fn main() {
     let mut apidoc = ApiDoc::openapi();
     apidoc.info.version = env!("CARGO_PKG_VERSION").to_string();
 
-    let json = apidoc.to_json().unwrap();
+    let json = apidoc.to_json().unwrap_or("".to_owned());
     std::fs::write("docs/static/openapi.json", json).unwrap();
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,11 +12,17 @@ pub enum ReconcileError {
     #[error("PropertyExtractionError '{0}' not found")]
     PropertyExtractionError(String),
 
-    #[error("GeneralError fetch error: {0}")]
-    GeneralError(#[from] kube::Error),
+    #[error("GeneralError error: {0}")]
+    GeneralError(String),
 
     #[error("Cannot send message in channel: {0}")]
     SendError(String),
+}
+
+impl From<kube::Error> for ReconcileError {
+    fn from(value: kube::Error) -> Self {
+        ReconcileError::GeneralError(format!("Error: {value}"))
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,10 @@ pub async fn process_check_result(
                 "https://api.telegram.org/bot{}/sendMessage",
                 channel.bot_token
             );
-            let timestamp_local = result.timestamp.unwrap().with_timezone(&Local);
+            let timestamp_local = result
+                .timestamp
+                .unwrap_or_else(Utc::now)
+                .with_timezone(&Local);
 
             match  http_client.post(&url).form(&[
                         ("chat_id", channel.chat_id.clone()),


### PR DESCRIPTION
Fixes #68 . 

Idea: ensure delete objects events are reported to Pinglow. In order to do this we add and remove a specific finalizer to block the object deletion in Kubernetes until Pinglow returns that the event was handled on its side. 